### PR TITLE
Old style exception to new style

### DIFF
--- a/Monitor/boop.py
+++ b/Monitor/boop.py
@@ -299,7 +299,7 @@ def main():
     display_art()
     try:
         configuration = Configuration()
-    except Exception,e:
+    except Exception as e:
         print(" [-]An error occured: "+str(e))
 
     print(c.OKBLUE+" [+] "+c.WHITE+"Time: "+c.OKGREEN+str(round(time.time() - start, 5)))


### PR DESCRIPTION
flake8 testing of https://github.com/MisterBianco/BoopSuite on Python 3.6.2

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Monitor/boop.py:302:21: E999 SyntaxError: invalid syntax
    except Exception,e:
                    ^
```